### PR TITLE
Add cleaner API "assert_that" on session and add an Expect catalog

### DIFF
--- a/examples/mcp_server_fetch/README.md
+++ b/examples/mcp_server_fetch/README.md
@@ -94,6 +94,29 @@ pytest tests/test_pytest_style.py
 
 ## Test Categories
 
+### Unified assertions and discovery catalog
+
+The examples use a single assertion entry point so you don't have to choose between immediate vs deferred checks. The framework decides based on whether you provide a `response`.
+
+We also expose a discovery-friendly catalog `A` for IntelliSense-driven exploration:
+
+```python
+from mcp_eval import Expect
+
+response = await agent.generate_str("Fetch https://example.com")
+
+# Content checks (immediate)
+session.assert_that(Expect.content.contains("Example Domain"), response=response)
+
+# Tool checks (deferred)
+session.assert_that(Expect.tools.was_called("fetch"))
+
+# LLM judge (async immediate; no await required)
+session.assert_that(Expect.judge.llm("Summarizes the page accurately", min_score=0.8), response=response)
+```
+
+Optionally override timing with `when="now" | "end"`.
+
 ### Basic Functionality
 - URL fetching
 - Content extraction

--- a/examples/mcp_server_fetch/tests/test_multi_criteria_judge.py
+++ b/examples/mcp_server_fetch/tests/test_multi_criteria_judge.py
@@ -1,10 +1,10 @@
 """Test MultiCriteriaJudge with enhanced evaluation capabilities."""
 
 import mcp_eval
+from mcp_eval import Expect
 from mcp_eval import task, setup
 from mcp_eval.evaluators import (
     STANDARD_CRITERIA,
-    MultiCriteriaJudge,
     EvaluationCriterion,
 )
 from mcp_eval.session import TestAgent, TestSession
@@ -45,18 +45,18 @@ async def test_standard_criteria_evaluation(agent: TestAgent, session: TestSessi
     ]
 
     # # Use MultiCriteriaJudge with weighted aggregation
-    judge = MultiCriteriaJudge(
+    judge = Expect.judge.multi_criteria(
         criteria=web_content_criteria,
         aggregate_method="weighted",
         use_cot=True,
         model="claude-3-5-haiku-20241022",
     )
 
-    await session.evaluate_now_async(
+    session.assert_that(
         judge,
-        input=input,
-        response=response,
         name="extraction_quality_assessment",
+        response=response,
+        input=input,
     )
 
 
@@ -89,7 +89,7 @@ async def test_require_all_pass_mode(agent: TestAgent, session: TestSession):
     ]
 
     # Use require_all_pass mode with minimum aggregation
-    judge = MultiCriteriaJudge(
+    judge = Expect.judge.multi_criteria(
         criteria=strict_criteria,
         require_all_pass=True,
         aggregate_method="min",
@@ -97,8 +97,8 @@ async def test_require_all_pass_mode(agent: TestAgent, session: TestSession):
         model="claude-3-5-haiku-20241022",
     )
 
-    await session.evaluate_now_async(
-        judge, input=input, response=response, name="strict_all_pass_evaluation"
+    session.assert_that(
+        judge, name="strict_all_pass_evaluation", response=response, input=input
     )
 
 
@@ -109,15 +109,15 @@ async def test_predefined_criteria_sets(agent: TestAgent, session: TestSession):
     response = await agent.generate_str(input)
 
     # Test with standard criteria using harmonic mean (penalizes low scores)
-    judge = MultiCriteriaJudge(
+    judge = Expect.judge.multi_criteria(
         criteria=STANDARD_CRITERIA,
         aggregate_method="harmonic_mean",
         include_confidence=True,
         model="claude-3-5-haiku-20241022",
     )
 
-    await session.evaluate_now_async(
-        judge, input=input, response=response, name="standard_criteria_harmonic"
+    session.assert_that(
+        judge, name="standard_criteria_harmonic", response=response, input=input
     )
 
 
@@ -155,24 +155,24 @@ async def test_error_handling(agent: TestAgent, session: TestSession):
     ]
 
     # Test with different aggregation methods for comparison
-    judge_weighted = MultiCriteriaJudge(
+    judge_weighted = Expect.judge.multi_criteria(
         criteria=error_handling_criteria,
         aggregate_method="weighted",
         use_cot=True,
         model="claude-3-5-haiku-20241022",
     )
 
-    await session.evaluate_now_async(
-        judge_weighted, input=input, response=response, name="error_handling_weighted"
+    session.assert_that(
+        judge_weighted, name="error_handling_weighted", response=response, input=input
     )
 
-    judge_min = MultiCriteriaJudge(
+    judge_min = Expect.judge.multi_criteria(
         criteria=error_handling_criteria,
         aggregate_method="min",
         use_cot=True,
         model="claude-3-5-haiku-20241022",
     )
 
-    await session.evaluate_now_async(
-        judge_min, input=input, response=response, name="error_handling_min"
+    session.assert_that(
+        judge_min, name="error_handling_min", response=response, input=input
     )

--- a/src/mcp_eval/__init__.py
+++ b/src/mcp_eval/__init__.py
@@ -4,6 +4,7 @@
 from mcp_eval.core import task, setup, teardown, parametrize
 from mcp_eval.datasets import Case, Dataset, generate_test_cases
 from mcp_eval.session import TestAgent, TestSession, test_session
+from mcp_eval.catalog import Expect
 
 # Configuration
 from mcp_eval.config import use_server, use_agent, use_llm_factory
@@ -61,4 +62,6 @@ __all__ = [
     "TestSession",
     "TestAgent",
     "test_session",
+    # Discovery catalog
+    "Expect",
 ]

--- a/src/mcp_eval/assertions/main.py
+++ b/src/mcp_eval/assertions/main.py
@@ -43,7 +43,7 @@ def contains(
     """Assert that response contains text."""
     session = _get_session() if session is None else session
     evaluator = ResponseContains(text=text, case_sensitive=case_sensitive)
-    session.evaluate_now(evaluator, response, f"contains_{text}")
+    session.assert_that(evaluator, name=f"contains_{text}", response=response)
 
 
 def not_contains(
@@ -51,56 +51,50 @@ def not_contains(
 ):
     """Assert that response does not contain text."""
     session = _get_session() if session is None else session
-
     evaluator = NotContains(text=text, case_sensitive=case_sensitive)
-    session.evaluate_now(evaluator, response, f"not_contains_{text}")
+    session.assert_that(evaluator, name=f"not_contains_{text}", response=response)
 
 
 def matches_regex(session: TestSession, response: str, pattern: str):
     """Assert that response matches regex pattern."""
     session = _get_session() if session is None else session
     evaluator = ResponseContains(text=pattern, regex=True)
-    session.evaluate_now(evaluator, response, "matches_regex")
+    session.assert_that(evaluator, name="matches_regex", response=response)
 
 
 def tool_was_called(session: TestSession, tool_name: str, min_times: int = 1):
     """Assert that a tool was called."""
     session = _get_session() if session is None else session
     evaluator = ToolWasCalled(tool_name=tool_name, min_times=min_times)
-    session.add_deferred_evaluator(evaluator, f"tool_called_{tool_name}")
+    session.assert_that(evaluator, name=f"tool_called_{tool_name}")
 
 
 def tool_was_called_with(session: TestSession, tool_name: str, arguments: dict):
     """Assert that a tool was called with specific arguments."""
     session = _get_session() if session is None else session
-
     evaluator = ToolCalledWith(tool_name, arguments)
-    session.add_deferred_evaluator(evaluator, f"tool_called_with_{tool_name}")
+    session.assert_that(evaluator, name=f"tool_called_with_{tool_name}")
 
 
 def tool_call_count(session: TestSession, tool_name: str, expected_count: int):
     """Assert exact tool call count."""
     session = _get_session() if session is None else session
-
     evaluator = ExactToolCount(tool_name, expected_count)
-    session.add_deferred_evaluator(
-        evaluator, f"tool_count_{tool_name}_{expected_count}"
-    )
+    session.assert_that(evaluator, name=f"tool_count_{tool_name}_{expected_count}")
 
 
 def tool_call_succeeded(session: TestSession, tool_name: str):
     """Assert that tool calls succeeded."""
     session = _get_session() if session is None else session
     evaluator = ToolSuccessRate(min_rate=1.0, tool_name=tool_name)
-    session.add_deferred_evaluator(evaluator, f"tool_succeeded_{tool_name}")
+    session.assert_that(evaluator, name=f"tool_succeeded_{tool_name}")
 
 
 def tool_call_failed(session: TestSession, tool_name: str):
     """Assert that tool calls failed."""
     session = _get_session() if session is None else session
-
     evaluator = ToolFailed(min_rate=0.0, tool_name=tool_name)
-    session.add_deferred_evaluator(evaluator, f"tool_failed_{tool_name}")
+    session.assert_that(evaluator, name=f"tool_failed_{tool_name}")
 
 
 def tool_success_rate(
@@ -109,21 +103,20 @@ def tool_success_rate(
     """Assert minimum tool success rate."""
     session = _get_session() if session is None else session
     evaluator = ToolSuccessRate(min_rate=min_rate, tool_name=tool_name)
-    session.add_deferred_evaluator(evaluator, f"success_rate_{min_rate}")
+    session.assert_that(evaluator, name=f"success_rate_{min_rate}")
 
 
 def completed_within(session: TestSession, max_iterations: int):
     """Assert task completed within max iterations - explicit session passing."""
     evaluator = MaxIterations(max_iterations=max_iterations)
-    session.add_deferred_evaluator(evaluator, f"max_iterations_{max_iterations}")
+    session.assert_that(evaluator, name=f"max_iterations_{max_iterations}")
 
 
 def response_time_under(session: TestSession, max_ms: float):
     """Assert response time is under threshold."""
     session = _get_session() if session is None else session
-
     evaluator = ResponseTimeCheck(max_ms)
-    session.add_deferred_evaluator(evaluator, f"response_time_under_{max_ms}")
+    session.assert_that(evaluator, name=f"response_time_under_{max_ms}")
 
 
 async def judge(
@@ -132,7 +125,8 @@ async def judge(
     """Use LLM to judge response quality."""
     session = _get_session() if session is None else session
     evaluator = LLMJudge(rubric=rubric, min_score=min_score)
-    await session.evaluate_now_async(evaluator, response, f"judge_{rubric[:20]}")
+    # Use unified API; it will schedule async eval now and await at session end.
+    session.assert_that(evaluator, name=f"judge_{rubric[:20]}", response=response)
 
 
 def tool_output_matches(
@@ -182,7 +176,7 @@ def tool_output_matches(
         case_sensitive=case_sensitive,
         call_index=call_index,
     )
-    session.add_deferred_evaluator(evaluator, f"tool_output_{tool_name}")
+    session.assert_that(evaluator, name=f"tool_output_{tool_name}")
 
 
 def path_efficiency(
@@ -235,4 +229,4 @@ def path_efficiency(
         tool_usage_limits=tool_usage_limits,
         default_tool_limit=default_tool_limit,
     )
-    session.add_deferred_evaluator(evaluator, "path_efficiency")
+    session.assert_that(evaluator, name="path_efficiency")

--- a/src/mcp_eval/catalog.py
+++ b/src/mcp_eval/catalog.py
@@ -1,0 +1,196 @@
+"""Discovery-friendly catalog of checks/evaluators.
+
+This module provides a single, IntelliSense-friendly surface area to discover
+what MCP-Eval supports. Use with the unified assertion API:
+
+    from mcp_eval import Expect
+    session.assert_that(Expect.tools.was_called("fetch"))
+    session.assert_that(Expect.content.contains("Example Domain"), response=response)
+
+The functions below return evaluator instances; they do not execute assertions
+themselves. Pair them with `session.assert_that(...)`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Pattern, Union
+
+from .evaluators import (
+    ToolWasCalled,
+    ToolSequence,
+    ResponseContains,
+    NotContains,
+    MaxIterations,
+    ToolSuccessRate,
+    LLMJudge,
+    ResponseTimeCheck,
+    ExactToolCount,
+    ToolFailed,
+    ToolCalledWith,
+    ToolOutputMatches,
+    PathEfficiency,
+    MultiCriteriaJudge,
+    EvaluationCriterion,
+)
+
+
+class Content:
+    """Content-focused checks."""
+
+    @staticmethod
+    def contains(text: str, *, case_sensitive: bool = False) -> ResponseContains:
+        return ResponseContains(text=text, case_sensitive=case_sensitive)
+
+    @staticmethod
+    def not_contains(text: str, *, case_sensitive: bool = False) -> NotContains:
+        return NotContains(text=text, case_sensitive=case_sensitive)
+
+    @staticmethod
+    def regex(pattern: str, *, case_sensitive: bool = False) -> ResponseContains:
+        return ResponseContains(text=pattern, case_sensitive=case_sensitive, regex=True)
+
+
+class Tools:
+    """Tool usage and behavior checks."""
+
+    @staticmethod
+    def was_called(tool_name: str, *, min_times: int = 1) -> ToolWasCalled:
+        return ToolWasCalled(tool_name=tool_name, min_times=min_times)
+
+    @staticmethod
+    def called_with(tool_name: str, arguments: Dict[str, Any]) -> ToolCalledWith:
+        return ToolCalledWith(tool_name, arguments)
+
+    @staticmethod
+    def count(tool_name: str, expected_count: int) -> ExactToolCount:
+        return ExactToolCount(tool_name, expected_count)
+
+    @staticmethod
+    def success_rate(min_rate: float, tool_name: Optional[str] = None) -> ToolSuccessRate:
+        return ToolSuccessRate(min_rate=min_rate, tool_name=tool_name)
+
+    @staticmethod
+    def failed(tool_name: str) -> ToolFailed:
+        return ToolFailed(min_rate=0.0, tool_name=tool_name)
+
+    @staticmethod
+    def output_matches(
+        tool_name: str,
+        expected_output: Union[Dict[str, Any], str, Pattern, int, float, List[Any]],
+        *,
+        field_path: Optional[str] = None,
+        match_type: str = "exact",
+        case_sensitive: bool = True,
+        call_index: int = -1,
+    ) -> ToolOutputMatches:
+        return ToolOutputMatches(
+            tool_name=tool_name,
+            expected_output=expected_output,
+            field_path=field_path,
+            match_type=match_type,  # type: ignore[arg-type]
+            case_sensitive=case_sensitive,
+            call_index=call_index,
+        )
+
+    @staticmethod
+    def sequence(sequence: List[str], *, allow_other_calls: bool = False) -> ToolSequence:
+        return ToolSequence(sequence, allow_other_calls=allow_other_calls)
+
+
+class Performance:
+    """Latency, iteration count, and related checks."""
+
+    @staticmethod
+    def max_iterations(max_iterations: int) -> MaxIterations:
+        return MaxIterations(max_iterations=max_iterations)
+
+    @staticmethod
+    def response_time_under(ms: float) -> ResponseTimeCheck:
+        return ResponseTimeCheck(ms)
+
+
+class Judge:
+    """LLM judge options."""
+
+    @staticmethod
+    def llm(rubric: str, *, min_score: float = 0.8, include_input: bool = False, require_reasoning: bool = True) -> LLMJudge:
+        return LLMJudge(rubric=rubric, min_score=min_score, include_input=include_input, require_reasoning=require_reasoning)
+
+    @staticmethod
+    def multi_criteria(
+        criteria: Dict[str, str] | List[EvaluationCriterion],
+        *,
+        aggregate_method: str = "weighted",
+        require_all_pass: bool = False,
+        include_confidence: bool = True,
+        use_cot: bool = True,
+        model: Optional[str] = None,
+    ) -> MultiCriteriaJudge:
+        # If dict is provided, convert to EvaluationCriterion list with default weights/min_scores
+        if isinstance(criteria, dict):
+            criteria = [
+                EvaluationCriterion(name=name, description=desc)
+                for name, desc in criteria.items()
+            ]
+        return MultiCriteriaJudge(
+            criteria=criteria,  # type: ignore[arg-type]
+            aggregate_method=aggregate_method,
+            require_all_pass=require_all_pass,
+            include_confidence=include_confidence,
+            use_cot=use_cot,
+            model=model,
+        )
+
+
+class Path:
+    """Path efficiency and related checks."""
+
+    @staticmethod
+    def efficiency(
+        *,
+        optimal_steps: Optional[int] = None,
+        expected_tool_sequence: Optional[List[str]] = None,
+        allow_extra_steps: int = 0,
+        penalize_backtracking: bool = True,
+        penalize_repeated_tools: bool = True,
+        tool_usage_limits: Optional[Dict[str, int]] = None,
+        default_tool_limit: int = 1,
+    ) -> PathEfficiency:
+        return PathEfficiency(
+            optimal_steps=optimal_steps,
+            expected_tool_sequence=expected_tool_sequence,
+            allow_extra_steps=allow_extra_steps,
+            penalize_backtracking=penalize_backtracking,
+            penalize_repeated_tools=penalize_repeated_tools,
+            tool_usage_limits=tool_usage_limits,
+            default_tool_limit=default_tool_limit,
+        )
+
+
+class Expect:
+    """Top-level discovery namespace.
+
+    - Expect.content.*    → content assertions
+    - Expect.tools.*      → tool usage/output assertions
+    - Expect.performance.*→ latency/iterations
+    - Expect.judge.*      → LLM judges
+    - Expect.path.*       → path efficiency/sequence
+    """
+
+    content = Content
+    tools = Tools
+    performance = Performance
+    judge = Judge
+    path = Path
+
+
+__all__ = [
+    "Expect",
+    "Content",
+    "Tools",
+    "Performance",
+    "Judge",
+    "Path",
+]
+
+


### PR DESCRIPTION
Simplify the API for developers:
- Get rid of `evaluate_now` and `add_deferred_evaluator` from the top-level API (even if that's what happens under the covers). Replaced with `session.assert_that` which will do the right thing depending on the assertion it's called with.
- @StreetLamb mentioned it's hard to know all the validators available with the framework, so I added a catalog.py with an `Expect` class to consolidate all possible assertions of the mcp-eval framework.