### PR TITLE
Update cli-reference.mdx

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -20,7 +20,7 @@ Examples:
 
 ```bash
 # Run a single file of decorator tests with verbose output and reports
-mcp-eval run examples/mcp_server_fetch/tests/test_decorator_style.py -v --json results.json --markdown results.md --html results.html
+mcp-eval run -v --json results.json --markdown results.md --html results.html examples/mcp_server_fetch/tests/test_decorator_style.py
 
 # Run a specific test function
 mcp-eval run examples/mcp_server_fetch/tests/test_decorator_style.py::test_basic_fetch_decorator


### PR DESCRIPTION
mcp-eval run examples/mcp_server_fetch/tests/test_decorator_style.py \
  -v \
  --markdown test-reports/results.md \
  --html test-reports/index.html

got updated to:

 Usage: mcp-eval run [OPTIONS] [TEST_DIR] COMMAND [ARGS]

## Summary

- What does this change do?

## Checklist

- [ ] Tests added/updated
- [x] Docs updated (README, docs/*.mdx)
- [ ] Lint passes locally
- [ ] Linked issue (if any)

## Screenshots / Logs

If applicable, add screenshots or logs.

## Breaking Changes

- [ ] Yes
- [ ] No

If yes, describe the migration path.
