### PR TITLE
Add help text and generate .gitignore for init command

### DIFF
--- a/src/mcp_eval/cli/generator.py
+++ b/src/mcp_eval/cli/generator.py
@@ -337,9 +337,9 @@ def _convert_servers_to_mcp_settings(
     return result
 
 
-def _load_existing_provider() -> tuple[
-    str | None, str | None, Dict[str, str], MCPEvalSettings
-]:
+def _load_existing_provider() -> (
+    tuple[str | None, str | None, Dict[str, str], MCPEvalSettings]
+):
     """Load existing provider configuration from environment and config files.
 
     Returns:
@@ -899,6 +899,17 @@ async def init_project(
 
     # Ensure mcpeval.yaml and secrets exist
     ensure_mcpeval_yaml(project)
+
+    # Create .gitignore if it doesn't exist
+    gitignore_path = project / ".gitignore"
+    if not gitignore_path.exists():
+        gitignore_content = """# mcp-eval
+mcpeval.secrets.yaml
+test-reports/
+.venv/
+"""
+        gitignore_path.write_text(gitignore_content.strip() + "\n", encoding="utf-8")
+        console.print(f"[green]✓[/] Created {gitignore_path}")
 
     # Copy packaged sample README if none exists
     readme_path = project / "README.md"
@@ -1715,6 +1726,11 @@ def init_project_cli(
         help="Bootstrap template: empty (no files), basic (config only), sample (examples + config)",
     ),
 ):
+    """Initialize an mcp-eval project with configuration files and usage examples.
+
+    Examples:
+        $ mcp-eval init
+    """
     return asyncio.run(init_project(out_dir=out_dir, template=template))
 
 


### PR DESCRIPTION
## Summary

- Generate .gitignore on `mcp-eval init` to ignore secrets, test-reports and .venv files
- Include help text for `init` command on `mcp-eval --help`

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (README, docs/*.mdx)
- [x] Lint passes locally
- [ ] Linked issue (if any)

## Screenshots / Logs

If applicable, add screenshots or logs.

## Breaking Changes

- [ ] Yes
- [x] No

If yes, describe the migration path.
