### PR TITLE
Increase maxTokens to 21K during test generation

### DIFF
--- a/src/mcp_eval/generation.py
+++ b/src/mcp_eval/generation.py
@@ -27,6 +27,7 @@ from mcp_eval.evaluators import (
 # mcp-agent integration for agent-driven scenario generation
 from mcp_agent.app import MCPApp
 from mcp_agent.agents.agent import Agent
+from mcp_agent.workflows.llm.augmented_llm import RequestParams
 from mcp_agent.workflows.factory import _llm_factory
 from mcp_agent.config import LoggerSettings
 from jinja2 import Environment, FileSystemLoader
@@ -578,7 +579,9 @@ async def generate_scenarios_with_agent(
                         pass
 
             bundle = await llm.generate_structured(
-                prompt, response_model=ScenarioBundle
+                prompt,
+                response_model=ScenarioBundle,
+                request_params=RequestParams(maxTokens=4096),
             )
             # Filter out any assertions that reference unknown tools
             if allowed_names:

--- a/src/mcp_eval/generation.py
+++ b/src/mcp_eval/generation.py
@@ -581,7 +581,7 @@ async def generate_scenarios_with_agent(
             bundle = await llm.generate_structured(
                 prompt,
                 response_model=ScenarioBundle,
-                request_params=RequestParams(maxTokens=4096),
+                request_params=RequestParams(maxTokens=21000),
             )
             # Filter out any assertions that reference unknown tools
             if allowed_names:


### PR DESCRIPTION
## Summary

- Address issue where `mcp-eval generate` might not work for MCP servers with more tools when generating using Anthropic models. Fixes #26  


## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (README, docs/*.mdx)
- [ ] Lint passes locally
- [x] Linked issue (if any)

## Screenshots / Logs

If applicable, add screenshots or logs.

## Breaking Changes

- [ ] Yes
- [x] No

If yes, describe the migration path.
