### PR TITLE
Fix action to only create empty report files if they don't exist

### DIFF
--- a/.github/actions/mcp-eval/run/action.yaml
+++ b/.github/actions/mcp-eval/run/action.yaml
@@ -250,10 +250,10 @@ runs:
           --html "${{ steps.compute-paths.outputs.html_path }}"
         ec=$?
         echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
-        # Ensure report files exist even on failure
-        : > "${{ steps.compute-paths.outputs.md_path }}" || true
-        : > "${{ steps.compute-paths.outputs.json_path }}" || true
-        : > "${{ steps.compute-paths.outputs.html_path }}" || true
+        # Ensure report files exist even on failure (only if they don't already exist)
+        [[ ! -f "${{ steps.compute-paths.outputs.md_path }}" ]] && : > "${{ steps.compute-paths.outputs.md_path }}" || true
+        [[ ! -f "${{ steps.compute-paths.outputs.json_path }}" ]] && : > "${{ steps.compute-paths.outputs.json_path }}" || true
+        [[ ! -f "${{ steps.compute-paths.outputs.html_path }}" ]] && : > "${{ steps.compute-paths.outputs.html_path }}" || true
         exit 0
 
     - name: Append report to step summary


### PR DESCRIPTION
## Summary

- Prevent generated mcpeval reports from being overwritten. Empty report files are now created only when no reports are produced.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (README, docs/*.mdx)
- [x] Lint passes locally
- [ ] Linked issue (if any)

## Screenshots / Logs

If applicable, add screenshots or logs.

## Breaking Changes

- [ ] Yes
- [x] No

If yes, describe the migration path.
